### PR TITLE
[FIX BUG] A error "Overriding method should call super.onCreate" occurs in FRAppCompatActivity#onCreate when it is applied in other project.

### DIFF
--- a/frfragmentlistener/src/main/java/org/fog_rock/frfragmentlistener/activity/FRAppCompatActivity.kt
+++ b/frfragmentlistener/src/main/java/org/fog_rock/frfragmentlistener/activity/FRAppCompatActivity.kt
@@ -1,7 +1,7 @@
 package org.fog_rock.frfragmentlistener.activity
 
-import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
 import org.fog_rock.frextensions.androidx.log.logI
 import org.fog_rock.frfragmentlistener.dialog.FRDialogFragment
 import org.fog_rock.frfragmentlistener.fragment.FRFragmentListener
@@ -12,13 +12,6 @@ import org.fog_rock.frfragmentlistener.fragment.FRFragmentListener
 open class FRAppCompatActivity: AppCompatActivity() {
 
     internal val fragmentListenerHolder: MutableMap<String, FRFragmentListener> = mutableMapOf()
-
-    private var enabledFragmentListenerRegistration = true
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enabledFragmentListenerRegistration = false
-    }
 
     /**
      * Register a dialog callback in the holder to receive the result from the dialog.
@@ -38,9 +31,9 @@ open class FRAppCompatActivity: AppCompatActivity() {
      * @see org.fog_rock.frfragmentlistener.fragment.restoreFragmentEventListener
      */
     fun registerForFragmentListener(listener: FRFragmentListener): String {
-        if (!enabledFragmentListenerRegistration) {
+        if (lifecycle.currentState.isAtLeast(Lifecycle.State.CREATED)) {
             throw IllegalStateException(
-                "Cannot register fragment listener. Must be called before Activity#onCreate().")
+                "Cannot register fragment listener. It must be called before CREATED stage.")
         }
         val key = "fragment_listener#${fragmentListenerHolder.size}"
         fragmentListenerHolder[key] = listener


### PR DESCRIPTION
* Apply lifecycle instead of flag to check the stage of Activity lifecycle.